### PR TITLE
Added: McNeil site data and apc ip for SCO.

### DIFF
--- a/website/ipam.json
+++ b/website/ipam.json
@@ -1,5 +1,5 @@
 {
-  "sites": ["sco", "leb", "mno", "hil", "azo", "client", "crw"],
+  "sites": ["sco", "leb", "mno", "hil", "azo", "client", "crw", "mcm"],
   "ips": [
     {
       "address": "44.34.129.49",
@@ -368,10 +368,18 @@
     {
       "address": "44.34.128.222",
       "name": "k4sof",
-      "site": "client",
-      "asset": null,
+      "site": "mcn",
+      "asset": "wlan1-gateway",
       "os": "routeros",
-      "cidr": null
+      "cidr": 28
+    },
+    {
+      "address": "44.34.129.147",
+      "name": "k4sof",
+      "site": "mcn",
+      "asset": "ether1",
+      "os": "routeros",
+      "cidr": 28
     },
     {
       "address": "44.34.128.175",
@@ -678,6 +686,38 @@
       "asset": null,
       "os": "ambient-weather",
       "cidr": 28
+    },
+    {
+      "address": "44.34.129.146",
+      "name": "ptpsam.ryan",
+      "site": "mcn",
+      "asset": "ether1-local",
+      "os": "routeros",
+      "cidr": 28
+    },
+    {
+      "address": "44.34.131.146",
+      "name": "ptpsam.ryan",
+      "site": "mcn",
+      "asset": "bridge1",
+      "os": "routeros",
+      "cidr": 32
+    },
+    {
+      "address": "44.34.128.38",
+      "name": "apc.sco",
+      "site": "sco",
+      "asset": null,
+      "os": "apc",
+      "cidr": 28
+    },
+    {
+      "address": "44.34.131.147",
+      "name": "ptpryan.sam",
+      "site": "mcn",
+      "asset": "bridge1",
+      "os": "routeros",
+      "cidr": 32
     }
   ]
 }


### PR DESCRIPTION
This PR covers the following 2 changes:
1. Created a new site mcm to represent the McNeil street HW that is now a core part of the network.
2. Added the IP address and hostname for the APC network card to be installed in SCO for the battery backup. 